### PR TITLE
Fixed bug where pagination.page was a string instead of a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function(pagination, options) {
   var type = options.hash.type || 'middle';
   var ret = '';
   var pageCount = pagination.pageCount;
-  var page = pagination.page;
+  var page = Number(pagination.page);
   var limit;
   if (options.hash.limit) limit = +options.hash.limit;
 


### PR DESCRIPTION
Because of using ===, no type inference is done and thus concatenation instead of addition occurs (ex: line 54) or equality checks fail (ex: line 50).
