### PR TITLE
Fix bug where pagination.pageCount was a string instead of a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function(pagination, options) {
   var type = options.hash.type || 'middle';
   var ret = '';
-  var pageCount = pagination.pageCount;
+  var pageCount = Number(pagination.pageCount);
   var page = Number(pagination.page);
   var limit;
   if (options.hash.limit) limit = +options.hash.limit;


### PR DESCRIPTION
@olalonde here is a fix that we needed because in some way we pass pageCount as a String instead a Number.

Thanks for it, works like a charm.
