### PR TITLE
Add "first" and "last" types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ template.hbs
 ```html
 <div class="pagination pagination-centered">
   <ul>
+    {{#paginate pagination type="first"}}
+      <li {{#if disabled}}class="disabled"{{/if}}><a href="?p={{n}}">First</a></li>
+    {{/paginate}}
     {{#paginate pagination type="previous"}}
-      <li {{#if disabled}}class="disabled"{{/if}}><a href="?p={{n}}" >Prev</a></li>
+      <li {{#if disabled}}class="disabled"{{/if}}><a href="?p={{n}}">Prev</a></li>
     {{/paginate}}
     {{#paginate pagination type="middle" limit="7"}}
       <li {{#if active}}class="active"{{/if}}><a href="?p={{n}}">{{n}}</a></li>
     {{/paginate}}
     {{#paginate pagination type="next"}}
       <li {{#if disabled}}class="disabled"{{/if}}><a href="?p={{n}}">Next</a></li>
+    {{/paginate}}
+    {{#paginate pagination type="last"}}
+      <li {{#if disabled}}class="disabled"{{/if}}><a href="?p={{n}}">Last</a></li>
     {{/paginate}}
   </ul>
 </div>

--- a/index.js
+++ b/index.js
@@ -55,6 +55,24 @@ module.exports = function(pagination, options) {
       }
       ret = ret + options.fn(newContext);
       break;
+    case 'first':
+      if (page === 1) {
+        newContext = { disabled: true, n: 1 }
+      }
+      else {
+        newContext = { n: 1 }
+      }
+      ret = ret + options.fn(newContext);
+      break;
+    case 'last':
+      if (page === pageCount) {
+        newContext = { disabled: true, n: pageCount }
+      }
+      else {
+        newContext = { n: pageCount }
+      }
+      ret = ret + options.fn(newContext);
+      break;
   }
 
   return ret;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Handlebars helper for pagination.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test/index.test.js"
   },
   "repository": {
     "type": "git",
@@ -16,5 +16,9 @@
     "paginate"
   ],
   "author": "Olivier Lalonde <olalonde@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "mocha": "^2.2.5",
+    "sinon": "^1.15.4"
+  }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,32 @@ describe('Handlebars Paginate Helper', function() {
     };
   });
 
+  describe('when type is "first"', function() {
+
+    beforeEach(function() {
+      options.hash.type = 'first';
+    });
+
+    it('should call options.fn with expected context', function() {
+      var cases = [{
+        input: { page: 1, pageCount: 3 },
+        expected: { disabled: true, n: 1 }
+      }, {
+        input: { page: 2, pageCount: 3 },
+        expected: { n: 1 }
+      }, {
+        input: { page: 3, pageCount: 3 },
+        expected: { n: 1 }
+      }];
+
+      cases.forEach(function(test) {
+        options.fn.reset();
+        paginate(test.input, options);
+        assert(options.fn.calledWith(test.expected));
+      });
+    });
+  });
+
   describe('when type is "previous"', function() {
 
     beforeEach(function() {
@@ -140,6 +166,32 @@ describe('Handlebars Paginate Helper', function() {
       }, {
         input: { page: 2, pageCount: 2 },
         expected: { disabled: true, n: 2 }
+      }];
+
+      cases.forEach(function(test) {
+        options.fn.reset();
+        paginate(test.input, options);
+        assert(options.fn.calledWith(test.expected));
+      });
+    });
+  });
+
+  describe('when type is "last"', function() {
+
+    beforeEach(function() {
+      options.hash.type = 'last';
+    });
+
+    it('should call options.fn with expected context', function() {
+      var cases = [{
+        input: { page: 1, pageCount: 3 },
+        expected: { n: 3 }
+      }, {
+        input: { page: 2, pageCount: 3 },
+        expected: { n: 3 }
+      }, {
+        input: { page: 3, pageCount: 3 },
+        expected: { disabled: true, n: 3 }
       }];
 
       cases.forEach(function(test) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,152 @@
+/*jshint node:true*/
+/*jshint mocha:true*/
+'use strict';
+
+var assert = require('assert');
+var sinon = require('sinon');
+var paginate = require('..');
+
+describe('Handlebars Paginate Helper', function() {
+  var options;
+
+  beforeEach(function() {
+    options = {
+      fn: sinon.stub(),
+      hash: {}
+    };
+  });
+
+  describe('when type is "previous"', function() {
+
+    beforeEach(function() {
+      options.hash.type = 'previous';
+    });
+
+    it('should call options.fn with expected context', function() {
+      var cases = [{
+        input: { page: 1, pageCount: 1 },
+        expected: { disabled: true, n: 1 }
+      }, {
+        input: { page: 2, pageCount: 2 },
+        expected: { n: 1 }
+      }];
+
+      cases.forEach(function(test) {
+        options.fn.reset();
+        paginate(test.input, options);
+        assert(options.fn.calledWith(test.expected));
+      });
+    });
+  });
+
+  describe('when type is "middle"', function() {
+
+    beforeEach(function() {
+      options.hash.type = 'middle';
+    });
+
+    describe('and limit is specified', function() {
+
+      beforeEach(function() {
+        options.hash.limit = 5;
+      });
+
+      it('should call options.fn with expected context', function() {
+        var cases = [{
+          input: { page: 1, pageCount: 7 },
+          expected: [
+            { n: 1, active: true },
+            { n: 2 },
+            { n: 3 },
+            { n: 4 },
+            { n: 5 }
+          ]
+        }, {
+          input: { page: 2, pageCount: 7 },
+          expected: [
+            { n: 1 },
+            { n: 2, active: true },
+            { n: 3 },
+            { n: 4 },
+            { n: 5 }
+          ]
+        }, {
+          input: { page: 3, pageCount: 7 },
+          expected: [
+            { n: 1 },
+            { n: 2 },
+            { n: 3, active: true },
+            { n: 4 },
+            { n: 5 }
+          ]
+        }, {
+          input: { page: 4, pageCount: 7 },
+          expected: [
+            { n: 2 },
+            { n: 3 },
+            { n: 4, active: true },
+            { n: 5 },
+            { n: 6 }
+          ]
+        }];
+
+        cases.forEach(function(test) {
+          options.fn.reset();
+          paginate(test.input, options);
+          test.expected.forEach(function(expected) {
+            assert(options.fn.calledWith(expected));
+          });
+        });
+      });
+    });
+
+    describe('and limit is not specified', function() {
+
+      it('should call options.fn with expected context', function() {
+        var cases = [{
+          input: { page: 1, pageCount: 7 },
+          expected: [
+            { n: 1, active: true },
+            { n: 2 },
+            { n: 3 },
+            { n: 4 },
+            { n: 5 },
+            { n: 6 },
+            { n: 7 }
+          ]
+        }];
+
+        cases.forEach(function(test) {
+          options.fn.reset();
+          paginate(test.input, options);
+          test.expected.forEach(function(expected) {
+            assert(options.fn.calledWith(expected));
+          });
+        });
+      });
+    });
+  });
+
+  describe('when type is "next"', function() {
+
+    beforeEach(function() {
+      options.hash.type = 'next';
+    });
+
+    it('should call options.fn with expected context', function() {
+      var cases = [{
+        input: { page: 1, pageCount: 2 },
+        expected: { n: 2 }
+      }, {
+        input: { page: 2, pageCount: 2 },
+        expected: { disabled: true, n: 2 }
+      }];
+
+      cases.forEach(function(test) {
+        options.fn.reset();
+        paginate(test.input, options);
+        assert(options.fn.calledWith(test.expected));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add handling for "first" and "last" page types.

Note: I took the liberty of adding tests. I hope you're okay with this. I checked out some of your other stuff, and found you were using mocha (+ chai) in one of your more recent projects, so I went with mocha, but I kept it as light as possible. If you don't want the tests for whatever reason, but are cool with the first/last feature, I can pull those commits out. I've tried to keep the styling as close to the existing as possible.