### PR TITLE
Support for URL to be passed in and full URL to be returned.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
-module.exports = function(pagination, options) {
-  var originalUrl = options.hash.originalUrl || '';
+module.exports = function (pagination, options) {
   var type = options.hash.type || 'middle';
   var ret = '';
+  var originalUrl = options.hash.originalUrl || 'http://localhost';
+  var fullUrl = new URL(originalUrl);
   var pageCount = Number(pagination.pageCount);
   var page = Number(pagination.page);
   var limit;
@@ -22,16 +23,23 @@ module.exports = function(pagination, options) {
         var start = page - leftCount;
 
         while (i < limit && i < pageCount) {
-          newContext = { n: start, originalUrl: originalUrl };
+          fullUrl.searchParams.set('page', start);
+          newContext = {
+            n: start,
+            fullUrl: fullUrl.href
+          };
           if (start === page) newContext.active = true;
           ret = ret + options.fn(newContext);
           start++;
           i++;
         }
-      }
-      else {
+      } else {
         for (var i = 1; i <= pageCount; i++) {
-          newContext = { n: i, originalUrl: originalUrl };
+          fullUrl.searchParams.set('page', i);
+          newContext = {
+            n: i,
+            fullUrl: fullUrl.href
+          };
           if (i === page) newContext.active = true;
           ret = ret + options.fn(newContext);
         }
@@ -39,38 +47,70 @@ module.exports = function(pagination, options) {
       break;
     case 'previous':
       if (page === 1) {
-        newContext = { disabled: true, n: 1, originalUrl: originalUrl }
-      }
-      else {
-        newContext = { n: page - 1, originalUrl: originalUrl }
+        fullUrl.searchParams.set('page', 1)
+        newContext = {
+          disabled: true,
+          n: 1,
+          fullUrl: fullUrl.href
+        }
+      } else {
+        fullUrl.searchParams.set('page', page - 1);
+        newContext = {
+          n: page - 1,
+          fullUrl: fullUrl.href
+        }
       }
       ret = ret + options.fn(newContext);
       break;
     case 'next':
       newContext = {};
       if (page === pageCount) {
-        newContext = { disabled: true, n: pageCount, originalUrl: originalUrl }
-      }
-      else {
-        newContext = { n: page + 1, originalUrl: originalUrl }
+        fullUrl.searchParams.set('page', pageCount);
+        newContext = {
+          disabled: true,
+          n: pageCount,
+          fullUrl: fullUrl.href
+        }
+      } else {
+        fullUrl.searchParams.set('page', page + 1);
+        newContext = {
+          n: page + 1,
+          fullUrl: fullUrl.href
+        }
       }
       ret = ret + options.fn(newContext);
       break;
     case 'first':
       if (page === 1) {
-        newContext = { disabled: true, n: 1, originalUrl: originalUrl }
-      }
-      else {
-        newContext = { n: 1, originalUrl: originalUrl }
+        fullUrl.searchParams.set('page', 1);
+        newContext = {
+          disabled: true,
+          n: 1,
+          fullUrl: fullUrl.href
+        }
+      } else {
+        fullUrl.searchParams.set('page', 1);
+        newContext = {
+          n: 1,
+          fullUrl: fullUrl.href
+        }
       }
       ret = ret + options.fn(newContext);
       break;
     case 'last':
       if (page === pageCount) {
-        newContext = { disabled: true, n: pageCount, originalUrl: originalUrl }
-      }
-      else {
-        newContext = { n: pageCount, originalUrl: originalUrl }
+        fullUrl.searchParams.set('page', pageCount);
+        newContext = {
+          disabled: true,
+          n: pageCount,
+          fullUrl: fullUrl.href
+        }
+      } else {
+        fullUrl.searchParams.set('page', pageCount);
+        newContext = {
+          n: pageCount,
+          fullUrl: fullUrl.href
+        }
       }
       ret = ret + options.fn(newContext);
       break;

--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ module.exports = function(pagination, options) {
       break;
     case 'previous':
       if (page === 1) {
-        newContext = { disabled: true, n: 1 }
+        newContext = { disabled: true, n: 1, originalUrl: originalUrl }
       }
       else {
-        newContext = { n: page - 1 }
+        newContext = { n: page - 1, originalUrl: originalUrl }
       }
       ret = ret + options.fn(newContext);
       break;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = function (pagination, options) {
   var type = options.hash.type || 'middle';
   var ret = '';
-  var originalUrl = pagination.originalUrl || 'http://localhost';
-  var fullUrl = new URL(originalUrl);
+  var url = pagination.url || 'http://localhost';
+  var paginatedUrl = new URL(url);
   var pageCount = Number(pagination.pageCount);
   var page = Number(pagination.page);
   var limit;
@@ -23,10 +23,10 @@ module.exports = function (pagination, options) {
         var start = page - leftCount;
 
         while (i < limit && i < pageCount) {
-          fullUrl.searchParams.set('page', start);
+          paginatedUrl.searchParams.set('page', start);
           newContext = {
             n: start,
-            fullUrl: fullUrl.href
+            paginatedUrl: paginatedUrl.href
           };
           if (start === page) newContext.active = true;
           ret = ret + options.fn(newContext);
@@ -35,10 +35,10 @@ module.exports = function (pagination, options) {
         }
       } else {
         for (var i = 1; i <= pageCount; i++) {
-          fullUrl.searchParams.set('page', i);
+          paginatedUrl.searchParams.set('page', i);
           newContext = {
             n: i,
-            fullUrl: fullUrl.href
+            paginatedUrl: paginatedUrl.href
           };
           if (i === page) newContext.active = true;
           ret = ret + options.fn(newContext);
@@ -47,17 +47,17 @@ module.exports = function (pagination, options) {
       break;
     case 'previous':
       if (page === 1) {
-        fullUrl.searchParams.set('page', 1)
+        paginatedUrl.searchParams.set('page', 1)
         newContext = {
           disabled: true,
           n: 1,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       } else {
-        fullUrl.searchParams.set('page', page - 1);
+        paginatedUrl.searchParams.set('page', page - 1);
         newContext = {
           n: page - 1,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       }
       ret = ret + options.fn(newContext);
@@ -65,51 +65,51 @@ module.exports = function (pagination, options) {
     case 'next':
       newContext = {};
       if (page === pageCount) {
-        fullUrl.searchParams.set('page', pageCount);
+        paginatedUrl.searchParams.set('page', pageCount);
         newContext = {
           disabled: true,
           n: pageCount,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       } else {
-        fullUrl.searchParams.set('page', page + 1);
+        paginatedUrl.searchParams.set('page', page + 1);
         newContext = {
           n: page + 1,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       }
       ret = ret + options.fn(newContext);
       break;
     case 'first':
       if (page === 1) {
-        fullUrl.searchParams.set('page', 1);
+        paginatedUrl.searchParams.set('page', 1);
         newContext = {
           disabled: true,
           n: 1,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       } else {
-        fullUrl.searchParams.set('page', 1);
+        paginatedUrl.searchParams.set('page', 1);
         newContext = {
           n: 1,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       }
       ret = ret + options.fn(newContext);
       break;
     case 'last':
       if (page === pageCount) {
-        fullUrl.searchParams.set('page', pageCount);
+        paginatedUrl.searchParams.set('page', pageCount);
         newContext = {
           disabled: true,
           n: pageCount,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       } else {
-        fullUrl.searchParams.set('page', pageCount);
+        paginatedUrl.searchParams.set('page', pageCount);
         newContext = {
           n: pageCount,
-          fullUrl: fullUrl.href
+          paginatedUrl: paginatedUrl.href
         }
       }
       ret = ret + options.fn(newContext);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = function(pagination, options) {
+  var originalUrl = options.hash.originalUrl || '';
   var type = options.hash.type || 'middle';
   var ret = '';
   var pageCount = Number(pagination.pageCount);
@@ -21,7 +22,7 @@ module.exports = function(pagination, options) {
         var start = page - leftCount;
 
         while (i < limit && i < pageCount) {
-          newContext = { n: start };
+          newContext = { n: start, originalUrl: originalUrl };
           if (start === page) newContext.active = true;
           ret = ret + options.fn(newContext);
           start++;
@@ -30,7 +31,7 @@ module.exports = function(pagination, options) {
       }
       else {
         for (var i = 1; i <= pageCount; i++) {
-          newContext = { n: i };
+          newContext = { n: i, originalUrl: originalUrl };
           if (i === page) newContext.active = true;
           ret = ret + options.fn(newContext);
         }
@@ -48,28 +49,28 @@ module.exports = function(pagination, options) {
     case 'next':
       newContext = {};
       if (page === pageCount) {
-        newContext = { disabled: true, n: pageCount }
+        newContext = { disabled: true, n: pageCount, originalUrl: originalUrl }
       }
       else {
-        newContext = { n: page + 1 }
+        newContext = { n: page + 1, originalUrl: originalUrl }
       }
       ret = ret + options.fn(newContext);
       break;
     case 'first':
       if (page === 1) {
-        newContext = { disabled: true, n: 1 }
+        newContext = { disabled: true, n: 1, originalUrl: originalUrl }
       }
       else {
-        newContext = { n: 1 }
+        newContext = { n: 1, originalUrl: originalUrl }
       }
       ret = ret + options.fn(newContext);
       break;
     case 'last':
       if (page === pageCount) {
-        newContext = { disabled: true, n: pageCount }
+        newContext = { disabled: true, n: pageCount, originalUrl: originalUrl }
       }
       else {
-        newContext = { n: pageCount }
+        newContext = { n: pageCount, originalUrl: originalUrl }
       }
       ret = ret + options.fn(newContext);
       break;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function (pagination, options) {
   var type = options.hash.type || 'middle';
   var ret = '';
-  var originalUrl = options.hash.originalUrl || 'http://localhost';
+  var originalUrl = pagination.originalUrl || 'http://localhost';
   var fullUrl = new URL(originalUrl);
   var pageCount = Number(pagination.pageCount);
   var page = Number(pagination.page);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "^2.2.5",
-    "sinon": "^1.15.4"
+    "sinon": "^1.17.7"
+  },
+  "dependencies": {
+    "assert": "^2.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,7 @@ var sinon = require('sinon');
 var paginate = require('..');
 
 var originalUrl = 'http://localhost';
-var expectedUrl = new URL(originalUrl);
+var paginatedUrl = new URL(originalUrl);
 
 function setPageParamAndGetUrlHref(url, n) {
   if (url instanceof URL === true) {
@@ -42,7 +42,7 @@ describe('Handlebars Paginate Helper', function () {
         expected: {
           disabled: true,
           n: 1,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
         }
       }, {
         input: {
@@ -51,7 +51,7 @@ describe('Handlebars Paginate Helper', function () {
         },
         expected: {
           n: 1,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
         }
       }, {
         input: {
@@ -60,7 +60,7 @@ describe('Handlebars Paginate Helper', function () {
         },
         expected: {
           n: 1,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
         }
       }];
 
@@ -87,7 +87,7 @@ describe('Handlebars Paginate Helper', function () {
         expected: {
           disabled: true,
           n: 1,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
         }
       }, {
         input: {
@@ -96,7 +96,7 @@ describe('Handlebars Paginate Helper', function () {
         },
         expected: {
           n: 1,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
         }
       }];
 
@@ -129,19 +129,19 @@ describe('Handlebars Paginate Helper', function () {
           expected: [{
             n: 1,
             active: true,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
           }, {
             n: 2,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 2)
           }, {
             n: 3,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
           }, {
             n: 4,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 4)
           }, {
             n: 5,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 5)
           }]
         }, {
           input: {
@@ -150,20 +150,20 @@ describe('Handlebars Paginate Helper', function () {
           },
           expected: [{
             n: 1,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
           }, {
             n: 2,
             active: true,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 2)
           }, {
             n: 3,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
           }, {
             n: 4,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 4)
           }, {
             n: 5,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 5)
           }]
         }, {
           input: {
@@ -172,20 +172,20 @@ describe('Handlebars Paginate Helper', function () {
           },
           expected: [{
             n: 1,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
           }, {
             n: 2,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 2)
           }, {
             n: 3,
             active: true,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
           }, {
             n: 4,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 4)
           }, {
             n: 5,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 5)
           }]
         }, {
           input: {
@@ -194,20 +194,20 @@ describe('Handlebars Paginate Helper', function () {
           },
           expected: [{
             n: 2,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 2)
           }, {
             n: 3,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
           }, {
             n: 4,
             active: true,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 4)
           }, {
             n: 5,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 5)
           }, {
             n: 6,
-            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 6)
+            paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 6)
           }]
         }];
 
@@ -232,28 +232,28 @@ describe('Handlebars Paginate Helper', function () {
           expected: [{
               n: 1,
               active: true,
-              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+              paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 1)
             }, {
               n: 2,
-              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+              paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 2)
             },
             {
               n: 3,
-              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+              paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
             },
             {
               n: 4,
-              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+              paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 4)
             },
             {
               n: 5,
-              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+              paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 5)
             }, {
               n: 6,
-              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 6)
+              paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 6)
             }, {
               n: 7,
-              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 7)
+              paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 7)
             }
           ]
         }];
@@ -283,7 +283,7 @@ describe('Handlebars Paginate Helper', function () {
         },
         expected: {
           n: 2,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 2)
         }
       }, {
         input: {
@@ -293,7 +293,7 @@ describe('Handlebars Paginate Helper', function () {
         expected: {
           disabled: true,
           n: 2,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 2)
         }
       }];
 
@@ -319,7 +319,7 @@ describe('Handlebars Paginate Helper', function () {
         },
         expected: {
           n: 3,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
         }
       }, {
         input: {
@@ -328,7 +328,7 @@ describe('Handlebars Paginate Helper', function () {
         },
         expected: {
           n: 3,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
         }
       }, {
         input: {
@@ -338,7 +338,7 @@ describe('Handlebars Paginate Helper', function () {
         expected: {
           disabled: true,
           n: 3,
-          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+          paginatedUrl: setPageParamAndGetUrlHref(paginatedUrl, 3)
         }
       }];
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,6 +6,8 @@ var assert = require('assert');
 var sinon = require('sinon');
 var paginate = require('..');
 
+var originalUrl = '';
+
 describe('Handlebars Paginate Helper', function() {
   var options;
 
@@ -25,13 +27,13 @@ describe('Handlebars Paginate Helper', function() {
     it('should call options.fn with expected context', function() {
       var cases = [{
         input: { page: 1, pageCount: 3 },
-        expected: { disabled: true, n: 1 }
+        expected: { disabled: true, n: 1, originalUrl: originalUrl }
       }, {
         input: { page: 2, pageCount: 3 },
-        expected: { n: 1 }
+        expected: { n: 1, originalUrl: originalUrl }
       }, {
         input: { page: 3, pageCount: 3 },
-        expected: { n: 1 }
+        expected: { n: 1, originalUrl: originalUrl }
       }];
 
       cases.forEach(function(test) {
@@ -51,10 +53,10 @@ describe('Handlebars Paginate Helper', function() {
     it('should call options.fn with expected context', function() {
       var cases = [{
         input: { page: 1, pageCount: 1 },
-        expected: { disabled: true, n: 1 }
+        expected: { disabled: true, n: 1, originalUrl: originalUrl }
       }, {
         input: { page: 2, pageCount: 2 },
-        expected: { n: 1 }
+        expected: { n: 1, originalUrl: originalUrl }
       }];
 
       cases.forEach(function(test) {
@@ -81,38 +83,38 @@ describe('Handlebars Paginate Helper', function() {
         var cases = [{
           input: { page: 1, pageCount: 7 },
           expected: [
-            { n: 1, active: true },
-            { n: 2 },
-            { n: 3 },
-            { n: 4 },
-            { n: 5 }
+            { n: 1, active: true, originalUrl: originalUrl },
+            { n: 2, originalUrl: originalUrl },
+            { n: 3, originalUrl: originalUrl },
+            { n: 4, originalUrl: originalUrl },
+            { n: 5, originalUrl: originalUrl }
           ]
         }, {
           input: { page: 2, pageCount: 7 },
           expected: [
-            { n: 1 },
-            { n: 2, active: true },
-            { n: 3 },
-            { n: 4 },
-            { n: 5 }
+            { n: 1, originalUrl: originalUrl },
+            { n: 2, active: true, originalUrl: originalUrl },
+            { n: 3, originalUrl: originalUrl },
+            { n: 4, originalUrl: originalUrl },
+            { n: 5, originalUrl: originalUrl }
           ]
         }, {
           input: { page: 3, pageCount: 7 },
           expected: [
-            { n: 1 },
-            { n: 2 },
-            { n: 3, active: true },
-            { n: 4 },
-            { n: 5 }
+            { n: 1, originalUrl: originalUrl },
+            { n: 2, originalUrl: originalUrl },
+            { n: 3, active: true, originalUrl: originalUrl },
+            { n: 4, originalUrl: originalUrl },
+            { n: 5, originalUrl: originalUrl }
           ]
         }, {
           input: { page: 4, pageCount: 7 },
           expected: [
-            { n: 2 },
-            { n: 3 },
-            { n: 4, active: true },
-            { n: 5 },
-            { n: 6 }
+            { n: 2, originalUrl: originalUrl },
+            { n: 3, originalUrl: originalUrl },
+            { n: 4, active: true, originalUrl: originalUrl },
+            { n: 5, originalUrl: originalUrl },
+            { n: 6, originalUrl: originalUrl }
           ]
         }];
 
@@ -132,13 +134,13 @@ describe('Handlebars Paginate Helper', function() {
         var cases = [{
           input: { page: 1, pageCount: 7 },
           expected: [
-            { n: 1, active: true },
-            { n: 2 },
-            { n: 3 },
-            { n: 4 },
-            { n: 5 },
-            { n: 6 },
-            { n: 7 }
+            { n: 1, active: true, originalUrl: originalUrl },
+            { n: 2, originalUrl: originalUrl },
+            { n: 3, originalUrl: originalUrl },
+            { n: 4, originalUrl: originalUrl },
+            { n: 5, originalUrl: originalUrl },
+            { n: 6, originalUrl: originalUrl },
+            { n: 7, originalUrl: originalUrl }
           ]
         }];
 
@@ -162,10 +164,10 @@ describe('Handlebars Paginate Helper', function() {
     it('should call options.fn with expected context', function() {
       var cases = [{
         input: { page: 1, pageCount: 2 },
-        expected: { n: 2 }
+        expected: { n: 2, originalUrl: originalUrl }
       }, {
         input: { page: 2, pageCount: 2 },
-        expected: { disabled: true, n: 2 }
+        expected: { disabled: true, n: 2, originalUrl: originalUrl }
       }];
 
       cases.forEach(function(test) {
@@ -185,13 +187,13 @@ describe('Handlebars Paginate Helper', function() {
     it('should call options.fn with expected context', function() {
       var cases = [{
         input: { page: 1, pageCount: 3 },
-        expected: { n: 3 }
+        expected: { n: 3, originalUrl: originalUrl }
       }, {
         input: { page: 2, pageCount: 3 },
-        expected: { n: 3 }
+        expected: { n: 3, originalUrl: originalUrl }
       }, {
         input: { page: 3, pageCount: 3 },
-        expected: { disabled: true, n: 3 }
+        expected: { disabled: true, n: 3, originalUrl: originalUrl }
       }];
 
       cases.forEach(function(test) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,37 +6,65 @@ var assert = require('assert');
 var sinon = require('sinon');
 var paginate = require('..');
 
-var originalUrl = '';
+var originalUrl = 'http://localhost';
+var expectedUrl = new URL(originalUrl);
 
-describe('Handlebars Paginate Helper', function() {
+function setPageParamAndGetUrlHref(url, n) {
+  if (url instanceof URL === true) {
+    url.searchParams.set('page', n);
+    return url.href;
+  }
+  return null;
+}
+
+describe('Handlebars Paginate Helper', function () {
   var options;
 
-  beforeEach(function() {
+  beforeEach(function () {
     options = {
       fn: sinon.stub(),
       hash: {}
     };
   });
 
-  describe('when type is "first"', function() {
+  describe('when type is "first"', function () {
 
-    beforeEach(function() {
+    beforeEach(function () {
       options.hash.type = 'first';
     });
 
-    it('should call options.fn with expected context', function() {
+    it('should call options.fn with expected context', function () {
       var cases = [{
-        input: { page: 1, pageCount: 3 },
-        expected: { disabled: true, n: 1, originalUrl: originalUrl }
+        input: {
+          page: 1,
+          pageCount: 3
+        },
+        expected: {
+          disabled: true,
+          n: 1,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+        }
       }, {
-        input: { page: 2, pageCount: 3 },
-        expected: { n: 1, originalUrl: originalUrl }
+        input: {
+          page: 2,
+          pageCount: 3
+        },
+        expected: {
+          n: 1,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+        }
       }, {
-        input: { page: 3, pageCount: 3 },
-        expected: { n: 1, originalUrl: originalUrl }
+        input: {
+          page: 3,
+          pageCount: 3
+        },
+        expected: {
+          n: 1,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+        }
       }];
 
-      cases.forEach(function(test) {
+      cases.forEach(function (test) {
         options.fn.reset();
         paginate(test.input, options);
         assert(options.fn.calledWith(test.expected));
@@ -44,22 +72,35 @@ describe('Handlebars Paginate Helper', function() {
     });
   });
 
-  describe('when type is "previous"', function() {
+  describe('when type is "previous"', function () {
 
-    beforeEach(function() {
+    beforeEach(function () {
       options.hash.type = 'previous';
     });
 
-    it('should call options.fn with expected context', function() {
+    it('should call options.fn with expected context', function () {
       var cases = [{
-        input: { page: 1, pageCount: 1 },
-        expected: { disabled: true, n: 1, originalUrl: originalUrl }
+        input: {
+          page: 1,
+          pageCount: 1
+        },
+        expected: {
+          disabled: true,
+          n: 1,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+        }
       }, {
-        input: { page: 2, pageCount: 2 },
-        expected: { n: 1, originalUrl: originalUrl }
+        input: {
+          page: 2,
+          pageCount: 2
+        },
+        expected: {
+          n: 1,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+        }
       }];
 
-      cases.forEach(function(test) {
+      cases.forEach(function (test) {
         options.fn.reset();
         paginate(test.input, options);
         assert(options.fn.calledWith(test.expected));
@@ -67,87 +108,160 @@ describe('Handlebars Paginate Helper', function() {
     });
   });
 
-  describe('when type is "middle"', function() {
+  describe('when type is "middle"', function () {
 
-    beforeEach(function() {
+    beforeEach(function () {
       options.hash.type = 'middle';
     });
 
-    describe('and limit is specified', function() {
+    describe('and limit is specified', function () {
 
-      beforeEach(function() {
+      beforeEach(function () {
         options.hash.limit = 5;
       });
 
-      it('should call options.fn with expected context', function() {
+      it('should call options.fn with expected context', function () {
         var cases = [{
-          input: { page: 1, pageCount: 7 },
-          expected: [
-            { n: 1, active: true, originalUrl: originalUrl },
-            { n: 2, originalUrl: originalUrl },
-            { n: 3, originalUrl: originalUrl },
-            { n: 4, originalUrl: originalUrl },
-            { n: 5, originalUrl: originalUrl }
-          ]
+          input: {
+            page: 1,
+            pageCount: 7
+          },
+          expected: [{
+            n: 1,
+            active: true,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          }, {
+            n: 2,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+          }, {
+            n: 3,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+          }, {
+            n: 4,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+          }, {
+            n: 5,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+          }]
         }, {
-          input: { page: 2, pageCount: 7 },
-          expected: [
-            { n: 1, originalUrl: originalUrl },
-            { n: 2, active: true, originalUrl: originalUrl },
-            { n: 3, originalUrl: originalUrl },
-            { n: 4, originalUrl: originalUrl },
-            { n: 5, originalUrl: originalUrl }
-          ]
+          input: {
+            page: 2,
+            pageCount: 7
+          },
+          expected: [{
+            n: 1,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          }, {
+            n: 2,
+            active: true,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+          }, {
+            n: 3,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+          }, {
+            n: 4,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+          }, {
+            n: 5,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+          }]
         }, {
-          input: { page: 3, pageCount: 7 },
-          expected: [
-            { n: 1, originalUrl: originalUrl },
-            { n: 2, originalUrl: originalUrl },
-            { n: 3, active: true, originalUrl: originalUrl },
-            { n: 4, originalUrl: originalUrl },
-            { n: 5, originalUrl: originalUrl }
-          ]
+          input: {
+            page: 3,
+            pageCount: 7
+          },
+          expected: [{
+            n: 1,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+          }, {
+            n: 2,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+          }, {
+            n: 3,
+            active: true,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+          }, {
+            n: 4,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+          }, {
+            n: 5,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+          }]
         }, {
-          input: { page: 4, pageCount: 7 },
-          expected: [
-            { n: 2, originalUrl: originalUrl },
-            { n: 3, originalUrl: originalUrl },
-            { n: 4, active: true, originalUrl: originalUrl },
-            { n: 5, originalUrl: originalUrl },
-            { n: 6, originalUrl: originalUrl }
-          ]
+          input: {
+            page: 4,
+            pageCount: 7
+          },
+          expected: [{
+            n: 2,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+          }, {
+            n: 3,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+          }, {
+            n: 4,
+            active: true,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+          }, {
+            n: 5,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+          }, {
+            n: 6,
+            fullUrl: setPageParamAndGetUrlHref(expectedUrl, 6)
+          }]
         }];
 
-        cases.forEach(function(test) {
+        cases.forEach(function (test) {
           options.fn.reset();
           paginate(test.input, options);
-          test.expected.forEach(function(expected) {
+          test.expected.forEach(function (expected) {
             assert(options.fn.calledWith(expected));
           });
         });
       });
     });
 
-    describe('and limit is not specified', function() {
+    describe('and limit is not specified', function () {
 
-      it('should call options.fn with expected context', function() {
+      it('should call options.fn with expected context', function () {
         var cases = [{
-          input: { page: 1, pageCount: 7 },
-          expected: [
-            { n: 1, active: true, originalUrl: originalUrl },
-            { n: 2, originalUrl: originalUrl },
-            { n: 3, originalUrl: originalUrl },
-            { n: 4, originalUrl: originalUrl },
-            { n: 5, originalUrl: originalUrl },
-            { n: 6, originalUrl: originalUrl },
-            { n: 7, originalUrl: originalUrl }
+          input: {
+            page: 1,
+            pageCount: 7
+          },
+          expected: [{
+              n: 1,
+              active: true,
+              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 1)
+            }, {
+              n: 2,
+              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+            },
+            {
+              n: 3,
+              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+            },
+            {
+              n: 4,
+              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 4)
+            },
+            {
+              n: 5,
+              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 5)
+            }, {
+              n: 6,
+              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 6)
+            }, {
+              n: 7,
+              fullUrl: setPageParamAndGetUrlHref(expectedUrl, 7)
+            }
           ]
         }];
 
-        cases.forEach(function(test) {
+        cases.forEach(function (test) {
           options.fn.reset();
           paginate(test.input, options);
-          test.expected.forEach(function(expected) {
+          test.expected.forEach(function (expected) {
             assert(options.fn.calledWith(expected));
           });
         });
@@ -155,22 +269,35 @@ describe('Handlebars Paginate Helper', function() {
     });
   });
 
-  describe('when type is "next"', function() {
+  describe('when type is "next"', function () {
 
-    beforeEach(function() {
+    beforeEach(function () {
       options.hash.type = 'next';
     });
 
-    it('should call options.fn with expected context', function() {
+    it('should call options.fn with expected context', function () {
       var cases = [{
-        input: { page: 1, pageCount: 2 },
-        expected: { n: 2, originalUrl: originalUrl }
+        input: {
+          page: 1,
+          pageCount: 2
+        },
+        expected: {
+          n: 2,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+        }
       }, {
-        input: { page: 2, pageCount: 2 },
-        expected: { disabled: true, n: 2, originalUrl: originalUrl }
+        input: {
+          page: 2,
+          pageCount: 2
+        },
+        expected: {
+          disabled: true,
+          n: 2,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 2)
+        }
       }];
 
-      cases.forEach(function(test) {
+      cases.forEach(function (test) {
         options.fn.reset();
         paginate(test.input, options);
         assert(options.fn.calledWith(test.expected));
@@ -178,25 +305,44 @@ describe('Handlebars Paginate Helper', function() {
     });
   });
 
-  describe('when type is "last"', function() {
+  describe('when type is "last"', function () {
 
-    beforeEach(function() {
+    beforeEach(function () {
       options.hash.type = 'last';
     });
 
-    it('should call options.fn with expected context', function() {
+    it('should call options.fn with expected context', function () {
       var cases = [{
-        input: { page: 1, pageCount: 3 },
-        expected: { n: 3, originalUrl: originalUrl }
+        input: {
+          page: 1,
+          pageCount: 3
+        },
+        expected: {
+          n: 3,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+        }
       }, {
-        input: { page: 2, pageCount: 3 },
-        expected: { n: 3, originalUrl: originalUrl }
+        input: {
+          page: 2,
+          pageCount: 3
+        },
+        expected: {
+          n: 3,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+        }
       }, {
-        input: { page: 3, pageCount: 3 },
-        expected: { disabled: true, n: 3, originalUrl: originalUrl }
+        input: {
+          page: 3,
+          pageCount: 3
+        },
+        expected: {
+          disabled: true,
+          n: 3,
+          fullUrl: setPageParamAndGetUrlHref(expectedUrl, 3)
+        }
       }];
 
-      cases.forEach(function(test) {
+      cases.forEach(function (test) {
         options.fn.reset();
         paginate(test.input, options);
         assert(options.fn.calledWith(test.expected));


### PR DESCRIPTION
I had the need to pass in URL so I don't have to add logic in every page where I also have search feature. Pull request introduces a feature where you can pass in URL to the helper and it will construct the correct URL and return its `href`, while maintaining other parameters you have in the URL.

Usage:
- Developers will be able to get pagination URL by doing `href="{{ paginatedUrl }}"` instead of `href="?page={{ n }}"`. 
- Default url is `http://localhost`, if you'd like to change it simply pass in `url` parameter to `pagination` hash, for example if you're using express:
```javascript
pagination: {
  page: 1,
  pageCount: 5,
  url: req.protocol + "://" + req.get('host') + req.originalUrl
}
```

`n` is still part of the returned object and can be used as necessary.